### PR TITLE
dispatch event even if there is no data.

### DIFF
--- a/amd/RNEventSource.js
+++ b/amd/RNEventSource.js
@@ -279,12 +279,6 @@ define(["require", "exports", "react-native", "event-target-shim", "./types"], f
         };
         RNEventSource.prototype.__dispatchBufferedEvent = function () {
             this._lastEventId = this._lastEventIdBuf;
-            // If the data buffer is an empty string, set the event type buffer to
-            // empty string and return
-            if (this._dataBuf === '') {
-                this._eventTypeBuf = '';
-                return;
-            }
             // Dispatch the event
             var eventType = this._eventTypeBuf || types_1.EventSourceEvent.MESSAGE;
             this.dispatchEvent({

--- a/es/RNEventSource.js
+++ b/es/RNEventSource.js
@@ -278,12 +278,6 @@ var RNEventSource = /** @class */ (function (_super) {
     };
     RNEventSource.prototype.__dispatchBufferedEvent = function () {
         this._lastEventId = this._lastEventIdBuf;
-        // If the data buffer is an empty string, set the event type buffer to
-        // empty string and return
-        if (this._dataBuf === '') {
-            this._eventTypeBuf = '';
-            return;
-        }
         // Dispatch the event
         var eventType = this._eventTypeBuf || EventSourceEvent.MESSAGE;
         this.dispatchEvent({

--- a/lib/RNEventSource.js
+++ b/lib/RNEventSource.js
@@ -282,12 +282,6 @@ var RNEventSource = /** @class */ (function (_super) {
     };
     RNEventSource.prototype.__dispatchBufferedEvent = function () {
         this._lastEventId = this._lastEventIdBuf;
-        // If the data buffer is an empty string, set the event type buffer to
-        // empty string and return
-        if (this._dataBuf === '') {
-            this._eventTypeBuf = '';
-            return;
-        }
         // Dispatch the event
         var eventType = this._eventTypeBuf || types_1.EventSourceEvent.MESSAGE;
         this.dispatchEvent({

--- a/src/RNEventSource.ts
+++ b/src/RNEventSource.ts
@@ -354,13 +354,6 @@ class RNEventSource extends (EventTarget(EVENT_SOURCE_EVENTS)) implements Extend
     private __dispatchBufferedEvent() {
         this._lastEventId = this._lastEventIdBuf;
 
-        // If the data buffer is an empty string, set the event type buffer to
-        // empty string and return
-        if (this._dataBuf === '') {
-            this._eventTypeBuf = '';
-            return;
-        }
-
         // Dispatch the event
         const eventType = this._eventTypeBuf || EventSourceEvent.MESSAGE;
         this.dispatchEvent({


### PR DESCRIPTION
I need to listen to [graphql-yoga](https://the-guild.dev/graphql/yoga-server) server-sent events.

If I `curl` my server which contains a simple subscription resolver that completes when `counter` equals 10:

`curl "http://localhost:8000/graphql?query=subscription\{counter\}"`

It responds with:
```
data: {"data":{"counter":0}}

data: {"data":{"counter":1}}

data: {"data":{"counter":2}}

data: {"data":{"counter":3}}

data: {"data":{"counter":4}}

data: {"data":{"counter":5}}

data: {"data":{"counter":6}}

data: {"data":{"counter":7}}

data: {"data":{"counter":8}}

data: {"data":{"counter":9}}

event: complete
```

With this change, I can listen to the `complete` event.

For example, you can now:

```javascript
import { RNEventSource } from "rn-eventsource-reborn";

const url = new URL("http://localhost:8000/graphql");
url.searchParams.set("query", "subscription { counter }");
const eventSource = new RNEventSource(url.toString());

eventSource.addEventListener("message", (event: any) => {
  if (event.data) {
    const data = JSON.parse(event.data);
    console.log("Data: ", data);
  }
});

eventSource.addEventListener("error", (event) => {
  console.log("Error: ", event);
});

eventSource.addEventListener("complete", () => {
  eventSource.close();
});
```

According to [mozilla](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event) I should be able to do just that:

`event`

A string identifying the type of event described. If this is specified, __an event will be dispatched on the browser to the listener for the specified event name__; the website source code __should use addEventListener() to listen for named events__. The onmessage handler is called if no event name is specified for a message.